### PR TITLE
Allow a value '0' for the slurm --mem parameter to allocate all available memory on each node.

### DIFF
--- a/slurm/BSS.py
+++ b/slurm/BSS.py
@@ -103,8 +103,8 @@ class BSS(BSSBase):
         if qos != "NONE":
             submit_cmds.append("#SBATCH --qos=%s" % qos)
         
-        if memory > 0:
-            # memory per node
+        if memory >= 0:
+            # memory per node, '0' means that the job requests all of the memory on each node
             submit_cmds.append("#SBATCH --mem=%s" % memory)
 
         if req_time > 0:


### PR DESCRIPTION
Allow '0' for the #SBATCH --mem parameter: this means that Slurm will allocate all available memory on each node to the job. Search for '--mem=' at https://slurm.schedmd.com/sbatch.html for more information.