### PR TITLE
Add support for Slurm '--comment' option

### DIFF
--- a/slurm/BSS.py
+++ b/slurm/BSS.py
@@ -48,6 +48,7 @@ class BSS(BSSBase):
         user_nodes_filter = extract_parameter(message, "BSS_NODES_FILTER", "NONE")
         qos = extract_parameter(message, "QOS", "NONE")
         exclusive = extract_parameter(message, "SSR_EXCLUSIVE", "NONE")
+        comment = extract_parameter(message, "SSR_COMMENT", "NONE")
 
         # jobname: check for illegal characters
         m = re.search(r"[^0-9a-zA-Z\.:.=~/]", jobname)
@@ -60,6 +61,9 @@ class BSS(BSSBase):
 
         if exclusive.lower() == "true":
             cmds.append("--exclusive")
+
+        if comment != "NONE":
+            cmds.append('--comment="%s"' % comment)
 
         if project != "NONE":
             cmds.append("--account=%s" % project)

--- a/tests/test_BSS_Slurm.py
+++ b/tests/test_BSS_Slurm.py
@@ -118,6 +118,20 @@ sleep 3
         self.assertTrue(self.has_directive(submit_cmds, "#SBATCH --mem", "0"))
         self.assertTrue(self.has_directive(submit_cmds, "#SBATCH --exclusive"))
 
+    def test_submit_comment(self):
+        os.chdir(basedir)
+        cwd = os.getcwd()
+        uspace = cwd + "/build/uspace-%s" % uuid.uuid4()
+        os.mkdir(uspace)
+        msg = """#!/bin/bash
+#TSI_SUBMIT
+#TSI_OUTCOME_DIR %s
+#TSI_USPACE_DIR %s
+#TSI_SSR_COMMENT test comment
+""" % (uspace, uspace)
+        submit_cmds = self.bss.create_submit_script(msg, self.config, self.LOG)
+        self.assertTrue(self.has_directive(submit_cmds, "#SBATCH --comment", "test comment"))
+
     def test_submit_nodes_filter(self):
         os.chdir(basedir)
         cwd = os.getcwd()


### PR DESCRIPTION
Support for Slurm '--comment' option: https://slurm.schedmd.com/sbatch.html#OPT_comment

UNICORE/X will send this 'comment' resource element to the TSI in upper case, with a "#TSI_SSR_" prefix.
https://unicore-docs.readthedocs.io/en/latest/admin-docs/unicorex/manual.html#summary

Thank you.